### PR TITLE
Allow 'all-projects' as a valid project name

### DIFF
--- a/pageviews.js
+++ b/pageviews.js
@@ -87,7 +87,7 @@ var pageviews = (function() {
         return new Error('Required parameter "project" missing.');
       }
     }
-    if ((params.project) && (params.project.indexOf('.') === -1)) {
+    if ((params.project) && ((params.project.indexOf('.') === -1 && params.project !== 'all-projects') ) {
       return new Error('Required parameter "project" invalid.');
     }
     if ((caller === 'getAggregatedPageviews') ||


### PR DESCRIPTION
Pageview API supports "all-projects" to get aggregate
data for all wikimedia projects
See: https://wikitech.wikimedia.org/wiki/Analytics/PageviewAPI#Pageviews_for_ALL_projects
