### PR TITLE
Adding support for legacy pagecounts

### DIFF
--- a/pageviews.js
+++ b/pageviews.js
@@ -54,7 +54,7 @@ var pageviews = (function() {
 
   var _accessSite = {
     default: 'all-sites',
-    allowed: ['all-sites', 'desktop-site', 'mobile-site']
+    allowed: ['all-sites', 'desktop-site', 'mobile-site', 'all-access']
   };
 
   var _agent = {

--- a/pageviews.js
+++ b/pageviews.js
@@ -412,7 +412,6 @@ var pageviews = (function() {
           'User-Agent': USER_AGENT
         }
       };
-      options.url = 'http://localhost:5000/legacy.json';
       request(options, function(error, response, body) {
         var result = _checkResult(error, response, body);
         if (result.stack) {

--- a/pageviews.js
+++ b/pageviews.js
@@ -405,7 +405,6 @@ var pageviews = (function() {
         url: BASE_URL + '/metrics/legacy-pageviews/per-project' +
             '/' + project +
             '/' + access +
-            '/' + agent +
             '/' + granularity +
             '/' + start +
             '/' + end,

--- a/pageviews.js
+++ b/pageviews.js
@@ -371,9 +371,9 @@ var pageviews = (function() {
     });
   };
 
-  var _getAggregatedLegacyPageviews = function(params) {
+  var _getAggregatedLegacyPagecounts = function(params) {
     return new Promise(function(resolve, reject) {
-      params = _checkParams(params, 'getAggregatedLegacyPageviews');
+      params = _checkParams(params, 'getAggregatedLegacyPagecounts');
       if (params.stack) {
         return reject(params);
       }
@@ -388,7 +388,7 @@ var pageviews = (function() {
           var newParams = params;
           delete newParams.projects;
           newParams.project = project;
-          promises[i] = _getAggregatedLegacyPageviews(newParams);
+          promises[i] = _getAggregatedLegacyPagecounts(newParams);
         });
         return resolve(Promise.all(promises));
       }
@@ -402,7 +402,7 @@ var pageviews = (function() {
       var granularity = params.granularity ?
           params.granularity : _granularityAggregated.default;
       var options = {
-        url: BASE_URL + '/metrics/legacy-pageviews/per-project' +
+        url: BASE_URL + '/metrics/legacy/pagecounts/per-project' +
             '/' + project +
             '/' + access +
             '/' + granularity +
@@ -552,9 +552,12 @@ var pageviews = (function() {
     getAggregatedPageviews: _getAggregatedPageviews,
 
     /**
-     * TODO document
+     * Given a date range between December 2007 and August 2016,
+     * returns a timeseries of pageview counts. You can filter by
+     * project and access method. You can choose between daily,
+     * hourly and monthly granularity as well.
      */
-    getAggregatedLegacyPageviews: _getAggregatedLegacyPageviews,
+    getAggregatedLegacyPagecounts: _getAggregatedLegacyPagecounts,
 
     /**
      * Lists the 1000 most viewed articles for a given project and timespan

--- a/test/pageviewsTest.js
+++ b/test/pageviewsTest.js
@@ -20,7 +20,7 @@ describe('pageviews.js', function() {
         'getPageviewsDimensions',
         'getPerArticlePageviews',
         'getAggregatedPageviews',
-        'getAggregatedLegacyPageviews',
+        'getAggregatedLegacyPagecounts',
         'getTopPageviews',
         'getUniqueDevices']);
   });
@@ -195,9 +195,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for a single project (date string).',
+  it('Returns aggregated legacy pagecounts for a single project (date string).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       project: 'en.wikipedia',
       start: '2008120101',
       end: '2008120102'
@@ -206,9 +206,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for a single project (date object).',
+  it('Returns aggregated legacy pagecounts for a single project (date object).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       project: 'en.wikipedia',
       start: new Date(2008, 12, 1, 1),
       end: new Date(2008, 12, 1, 2)
@@ -217,9 +217,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for a single project ' +
+  it('Returns aggregated legacy pagecounts for a single project ' +
       '(date object, no padding).', function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       project: 'en.wikipedia',
       start: new Date('2008-12-10'),
       end: new Date('2008-12-20'),
@@ -230,9 +230,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for multiple projects (date string).',
+  it('Returns aggregated legacy pagecounts for multiple projects (date string).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       projects: ['en.wikipedia', 'de.wikipedia'],
       start: '2008120101',
       end: '2008120101'
@@ -241,9 +241,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for multiple projects (date object).',
+  it('Returns aggregated legacy pagecounts for multiple projects (date object).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       projects: ['en.wikipedia', 'de.wikipedia'],
       start: new Date(2008, 12, 1, 1),
       end: new Date(2008, 12, 1, 2)
@@ -252,9 +252,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for all projects (plural, date object).',
+  it('Returns aggregated legacy pagecounts for all projects (plural, date object).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       projects: 'all-projects',
       start: new Date(2008, 12, 1, 1),
       end: new Date(2008, 12, 1, 2)
@@ -263,9 +263,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for all projects (plural) ' +
+  it('Returns aggregated legacy pagecounts for all projects (plural) ' +
       'and a particular project (date object).', function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       projects: ['all-projects', 'en.wikipedia'],
       start: new Date(2008, 12, 1, 1),
       end: new Date(2008, 12, 1, 2)
@@ -274,9 +274,9 @@ describe('pageviews.js', function() {
     });
   });
 
-  it('Returns aggregated legacy pageviews for all projects (singular, date object).',
+  it('Returns aggregated legacy pagecounts for all projects (singular, date object).',
       function() {
-    return pageviews.getAggregatedLegacyPageviews({
+    return pageviews.getAggregatedLegacyPagecounts({
       project: 'all-projects',
       start: new Date(2008, 12, 1, 1),
       end: new Date(2008, 12, 1, 2)

--- a/test/pageviewsTest.js
+++ b/test/pageviewsTest.js
@@ -20,6 +20,7 @@ describe('pageviews.js', function() {
         'getPageviewsDimensions',
         'getPerArticlePageviews',
         'getAggregatedPageviews',
+        'getAggregatedLegacyPageviews',
         'getTopPageviews',
         'getUniqueDevices']);
   });
@@ -189,6 +190,96 @@ describe('pageviews.js', function() {
       project: 'all-projects',
       start: new Date(new Date() - 3 * 24 * 60 * 60 * 1000),
       end: new Date(new Date() - 2 * 24 * 60 * 60 * 1000)
+    }).then(function(result) {
+      assert(result.items[0].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for a single project (date string).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      project: 'en.wikipedia',
+      start: '2008120101',
+      end: '2008120102'
+    }).then(function(result) {
+      assert(result.items[0].views >= 0 && result.items[1].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for a single project (date object).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      project: 'en.wikipedia',
+      start: new Date(2008, 12, 1, 1),
+      end: new Date(2008, 12, 1, 2)
+    }).then(function(result) {
+      assert(result.items[0].views >= 0 && result.items[1].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for a single project ' +
+      '(date object, no padding).', function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      project: 'en.wikipedia',
+      start: new Date('2008-12-10'),
+      end: new Date('2008-12-20'),
+      granularity: 'daily'
+    }).then(function(result) {
+      assert(result.items[0].views >= 0 && result.items[1].views >= 0);
+      assert.equal(result.items[0].timestamp, '2008121000');
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for multiple projects (date string).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      projects: ['en.wikipedia', 'de.wikipedia'],
+      start: '2008120101',
+      end: '2008120101'
+    }).then(function(result) {
+      assert(result[0].items[0].views >= 0 && result[1].items[0].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for multiple projects (date object).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      projects: ['en.wikipedia', 'de.wikipedia'],
+      start: new Date(2008, 12, 1, 1),
+      end: new Date(2008, 12, 1, 2)
+    }).then(function(result) {
+      assert(result[0].items[0].views >= 0 && result[1].items[0].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for all projects (plural, date object).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      projects: 'all-projects',
+      start: new Date(2008, 12, 1, 1),
+      end: new Date(2008, 12, 1, 2)
+    }).then(function(result) {
+      assert(result.items[0].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for all projects (plural) ' +
+      'and a particular project (date object).', function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      projects: ['all-projects', 'en.wikipedia'],
+      start: new Date(2008, 12, 1, 1),
+      end: new Date(2008, 12, 1, 2)
+    }).then(function(result) {
+      assert(result[0].items[0].views >= 0 && result[1].items[0].views >= 0);
+    });
+  });
+
+  it('Returns aggregated legacy pageviews for all projects (singular, date object).',
+      function() {
+    return pageviews.getAggregatedLegacyPageviews({
+      project: 'all-projects',
+      start: new Date(2008, 12, 1, 1),
+      end: new Date(2008, 12, 1, 2)
     }).then(function(result) {
       assert(result.items[0].views >= 0);
     });


### PR DESCRIPTION
Hi @tomayac!

We are currently about to deploy a new endpoint to the Analytics Query Service that allows querying aggregated pagecount data between 2007 and 2016 (the current endpoint allows queries from July 2015 onwards), in hourly, daily, and monthly granularities. I've added a handler method and corresponding tests following the code that was already there. I'm also adding `all-access` as allowed access site value. 

Currently [one test](https://github.com/fdansv/pageviews.js/blob/legacy-pageviews/test/pageviewsTest.js#L220-L231) depends on the endpoint being up, and therefore will fail until it is deployed.